### PR TITLE
fix: ReferenceError part is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ let force_numbers_into_order = (str) => (
 
 let separate_extensions = (ary) => {
   let result = [];
-  for (part of ary) {
+  for (let part of ary) {
     let i = part.indexOf(".");
     if (i === -1) {
       result.push(part);


### PR DESCRIPTION
without let / const, `for(variable of array)` will cause ReferenceError in strict mode or ES module environment.

![image](https://user-images.githubusercontent.com/4067115/223320202-fe166cb1-c314-4342-af44-567e52841950.png)
